### PR TITLE
Fix support for alpine 

### DIFF
--- a/.github/workflows/goBuild.yaml
+++ b/.github/workflows/goBuild.yaml
@@ -26,8 +26,11 @@ jobs:
     - name: Install dependencies
       run: go get .
 
+    - name: Set environment
+      run: env CGO_ENABLED=0 & env GOOS=linux & env GOARCH=amd64
+
     - name: Build
-      run: env CGO_ENABLED=0 & go build
+      run: go build -tags netgo -a -v
 
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag goxdcc:$(date +%s)


### PR DESCRIPTION
Alpine doesn't support linked executables thus:

CGO_ENABLED=0 is needed as go links to native network libs.
-tags netgo will compile the net libraries in pure go instead of linking to native or c
-a will force build everything
-v will print everything that's build